### PR TITLE
Add parameter to choose journal date format

### DIFF
--- a/open_journal.py
+++ b/open_journal.py
@@ -14,12 +14,14 @@ try:
 except ImportError:
     from mdeutils import *
 
-
+DEFAULT_DATE_FORMAT = '%Y-%m-%d'
+    
 class OpenJournalCommand(MDETextCommand):
     def run(self, edit):
         print("Running OpenJournalCommand")        
         today = date.today()
-        name = today.strftime('%Y-%m-%d')
+        date_format = self.view.settings().get("mde.journal.dateformat", DEFAULT_DATE_FORMAT)
+        name = today.strftime(date_format)
 
         wiki_page = WikiPage(self.view)
         wiki_page.select_page(name)


### PR DESCRIPTION
This allows for other journal date formats to be permissible, adding an optional date format parameter to the setting file.